### PR TITLE
comparing le + offset to file size in processReadBinary

### DIFF
--- a/src/net/pwendland/javacard/pki/isoapplet/IsoFileSystem.java
+++ b/src/net/pwendland/javacard/pki/isoapplet/IsoFileSystem.java
@@ -701,10 +701,10 @@ public class IsoFileSystem extends DedicatedFile {
          * The host may request all the data (up to 256 Bytes) with Le=00, but the data might be smaller.
          * This is a valid request; we have to send all the data (even if less than 256 Bytes).
          */
-        if(le+offset >= fileData.length) {
-            le = (short)(fileData.length - offset);
+        short maxle = (short)(fileData.length - offset);
+        if(le > maxle) {
+            le = maxle;
         }
-
         apdu.setOutgoingLength(le);
         apdu.sendBytesLong(fileData, offset, le);
     }

--- a/src/net/pwendland/javacard/pki/isoapplet/IsoFileSystem.java
+++ b/src/net/pwendland/javacard/pki/isoapplet/IsoFileSystem.java
@@ -701,8 +701,8 @@ public class IsoFileSystem extends DedicatedFile {
          * The host may request all the data (up to 256 Bytes) with Le=00, but the data might be smaller.
          * This is a valid request; we have to send all the data (even if less than 256 Bytes).
          */
-        if((short) (le+offset) >= (short) fileData.length) {
-            le = (short)((short)(fileData.length) - offset);
+        if(le+offset >= fileData.length) {
+            le = (short)(fileData.length - offset);
         }
 
         apdu.setOutgoingLength(le);


### PR DESCRIPTION
The comparison should use normal integers since le+offset can be greater than 32767. The difference can be cast back to a short. 