### PR TITLE
Always use ECDSA with off card hashing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -8,7 +8,7 @@
     <target name="dist" description="generate the distribution">
         <tstamp/>
         <javacard jckit="ext/sdks/jc305u3_kit">
-            <cap targetsdk="ext/sdks/jc222_kit" aid="f2:76:a2:88:bc:fb:a6:9d:34:f3:10" output="IsoApplet.cap" sources="src" version="1.0">
+            <cap targetsdk="ext/sdks/jc304_kit" aid="f2:76:a2:88:bc:fb:a6:9d:34:f3:10" output="IsoApplet.cap" sources="src" version="1.0">
                 <applet class="net.pwendland.javacard.pki.isoapplet.IsoApplet" aid="f2:76:a2:88:bc:fb:a6:9d:34:f3:10:01"/>
             </cap>
         </javacard>

--- a/src/net/pwendland/javacard/pki/isoapplet/IsoApplet.java
+++ b/src/net/pwendland/javacard/pki/isoapplet/IsoApplet.java
@@ -37,6 +37,7 @@ import javacard.security.ECPrivateKey;
 import javacardx.crypto.Cipher;
 import javacardx.apdu.ExtendedLength;
 import javacard.security.CryptoException;
+import javacard.security.MessageDigest;
 import javacard.security.Signature;
 import javacard.security.RandomData;
 
@@ -54,8 +55,8 @@ import javacard.security.RandomData;
  */
 public class IsoApplet extends Applet implements ExtendedLength {
     /* API Version */
-    public static final byte API_VERSION_MAJOR = (byte) 0x00;
-    public static final byte API_VERSION_MINOR = (byte) 0x06;
+    public static final byte API_VERSION_MAJOR = (byte) 0x01;
+    public static final byte API_VERSION_MINOR = (byte) 0x00;
 
     /* Card-specific configuration */
     public static final boolean DEF_EXT_APDU = false;
@@ -184,7 +185,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
         rsaPkcs1Cipher = Cipher.getInstance(Cipher.ALG_RSA_PKCS1, false);
 
         try {
-            ecdsaSignature = Signature.getInstance(Signature.ALG_ECDSA_SHA, false);
+            ecdsaSignature = Signature.getInstance(MessageDigest.ALG_NULL, Signature.SIG_CIPHER_ECDSA, Cipher.PAD_NULL, false);
             api_features |= API_FEATURE_ECC;
         } catch (CryptoException e) {
             if(e.getReason() == CryptoException.NO_SUCH_ALGORITHM) {


### PR DESCRIPTION
With this PR raw ECDSA without hashing is performed instead of ECDSA with SHA1 hashing.
The hashing has now to be done on the host side (See https://github.com/OpenSC/OpenSC/pull/2642).

The benefit of this is that all ECDSA mechanisms of the pkcs#11 interface can be used with the ISOApplet.