### PR TITLE
use ram buffer large requests/responses and only signal RSA PSS support if all hash schemes are supported

### DIFF
--- a/src/xyz/wendland/javacard/pki/isoapplet/IsoApplet.java
+++ b/src/xyz/wendland/javacard/pki/isoapplet/IsoApplet.java
@@ -1208,7 +1208,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
         short lc = readIncomingDataIntoRam(apdu);
 
         // Padding indicator should be "No further indication".
-        if(ram_buf[apdu.getOffsetCdata()] != (byte) 0x00) {
+        if(ram_buf[0] != (byte) 0x00) {
             ISOException.throwIt(ISO7816.SW_WRONG_DATA);
         }
 

--- a/src/xyz/wendland/javacard/pki/isoapplet/IsoApplet.java
+++ b/src/xyz/wendland/javacard/pki/isoapplet/IsoApplet.java
@@ -1707,9 +1707,9 @@ public class IsoApplet extends Applet implements ExtendedLength {
         if(le <= 0 || le > 256) {
             ISOException.throwIt(ISO7816.SW_WRONG_LENGTH);
         }
-        randomData.generateData(buf, (short)0, le);
+        randomData.generateData(ram_buf, (short)0, le);
         apdu.setOutgoingLength(le);
-        apdu.sendBytes((short)0, le);
+        apdu.sendBytesLong(ram_buf, (short)0, le);
     }
 
 } // class IsoApplet

--- a/src/xyz/wendland/javacard/pki/isoapplet/UtilTLV.java
+++ b/src/xyz/wendland/javacard/pki/isoapplet/UtilTLV.java
@@ -197,6 +197,9 @@ public class UtilTLV {
         if(len < 0) {
             throw InvalidArgumentsException.getInstance();
         }
+        if((short)(tagLen + getLengthFieldLength(len)) > (short)(outLen - outOffset)) {
+            throw NotEnoughSpaceException.getInstance();
+        }
 
         if(tagLen == 1) {
             out[pos] = (byte)(tag & (short)0x00FF);


### PR DESCRIPTION
When testing the isoapplet-v1 changes with real hardware instead of the simulator, I found that the size of the APDU buffer is not large enough to hold all data, e.g. when sending the public EC key, even if extended APDUs are used.

I found in the JavaCard API docs that the guaranteed length of the APDU buffer is only 133 bytes  (the buffer size of the smart card that I use for testing is 261 byte).

Therefore, I revived the ram buffer from the v0 version.
I have already tested EC and RSA Keygen, ECDSA and RSA-PKCS1 signature creation and EC/RSA key import.
RSA-PSS signatures and RSA decryption have not been tested yet.