### PR TITLE
Support jcardsim and J3H081

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-ant-javacard.jar
 doc
 *.swp
 *.orig
 *.un~
 *.cap
+*.jar

--- a/README.md
+++ b/README.md
@@ -37,5 +37,31 @@ After cloning the IsoApplet repository, all you have to do is:
 # Installation
 Install the CAP-file (IsoApplet.cap) to your Java Card smart card (e.g. with [GlobalPlatformPro](https://github.com/martinpaljak/GlobalPlatformPro)).
 
+# Using with jcardsim
+Make sure to install the appropriate vsmartcard package. On Debian/Ubuntu, this is called vsmartcard-vpcd. You may need to restart pcscd after installing it. Note: This is only appropriate for development machines; it creates an open listening socket with no authentication that pcscd exposes as the first reader so it is trivial to MitM for an attacker.
+
+Setup a jcardsim.cfg file like so:
+```
+com.licel.jcardsim.card.applet.0.AID=F276A288BCFBA69D34F31001
+com.licel.jcardsim.card.applet.0.Class=xyz.wendland.javacard.pki.isoapplet.IsoApplet
+com.licel.jcardsim.terminal.type=2
+com.licel.jcardsim.vsmartcard.host=127.0.0.1
+com.licel.jcardsim.vsmartcard.port=35963
+```
+
+Run jcardsim with the IsoApplet.jar file on the path:
+```java -cp IsoApplet.jar:jcardsim-3.0.5-SNAPSHOT.jar com.licel.jcardsim.remote.VSmartCard  jcardsim.cfg```
+
+Instantiate the applet in jcardsim (this example uses gpshell):
+```
+echo 'establish_context
+card_connect
+send_apdu -sc 0 -APDU 80b800000d0cF276A288BCFBA69D34F31001
+card_disconnect
+release_context' | gpshell
+```
+
+Now you should be able to use pkcs15-init and friends.
+
 **Have a look at the wiki for more information:** https://github.com/philipWendland/IsoApplet/wiki
 

--- a/build.xml
+++ b/build.xml
@@ -8,7 +8,7 @@
     <target name="dist" description="generate the distribution">
         <tstamp/>
         <javacard jckit="ext/sdks/jc310r20210706_kit">
-            <cap targetsdk="ext/sdks/jc304_kit" aid="f2:76:a2:88:bc:fb:a6:9d:34:f3:10" output="IsoApplet.cap" sources="src" version="1.0">
+            <cap targetsdk="ext/sdks/jc304_kit" aid="f2:76:a2:88:bc:fb:a6:9d:34:f3:10" output="IsoApplet.cap" sources="src" version="1.0" jar="IsoApplet.jar">
                 <applet class="xyz.wendland.javacard.pki.isoapplet.IsoApplet" aid="f2:76:a2:88:bc:fb:a6:9d:34:f3:10:01"/>
             </cap>
         </javacard>


### PR DESCRIPTION
jcardsim's PersistentSimulatorRuntime cannot persist Signature objects, so make those temporary and not part of the class object. Additionally, allow skipping checks for RSA4096 and for RSA PSS, as even just testing them can prevent applet installation on certain cards (J3H081).