### PR TITLE
Off-card hashing ECDSA for NXP JCOP 4 and JCardEngine

### DIFF
--- a/src/xyz/wendland/javacard/pki/isoapplet/IsoApplet.java
+++ b/src/xyz/wendland/javacard/pki/isoapplet/IsoApplet.java
@@ -22,6 +22,7 @@ package xyz.wendland.javacard.pki.isoapplet;
 import javacard.framework.Applet;
 import javacard.framework.ISO7816;
 import javacard.framework.ISOException;
+import javacard.framework.TransactionException;
 import javacard.framework.APDU;
 import javacard.framework.JCSystem;
 import javacard.framework.Util;
@@ -138,6 +139,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
     private Key[] keys = null;
     private byte[] ram_buf = null;
     private Cipher rsaPkcs1Cipher = null;
+    private boolean usePrecomputedHashEcdsa = false;
     private Signature ecdsaSignature = null;
     private Signature rsaSha1PssSignature = null;
     private Signature rsaSha224PssSignature = null;
@@ -180,27 +182,41 @@ public class IsoApplet extends Applet implements ExtendedLength {
         // API features: probe card support for ECDSA
         try {
             ecdsaSignature = Signature.getInstance(MessageDigest.ALG_NULL, Signature.SIG_CIPHER_ECDSA, Cipher.PAD_NULL, false);
+            usePrecomputedHashEcdsa = false;
             api_features |= API_FEATURE_ECC;
         } catch (CryptoException e) {
             if(e.getReason() == CryptoException.NO_SUCH_ALGORITHM) {
                 /* Few Java Cards do not support ECDSA at all.
                  * We should not throw an exception in this cases
-                 * as this would prevent installation. */
+                 * as this would prevent installation, and we
+                 * trying a different mechanism just after. */
                 ecdsaSignature = null;
-                api_features &= ~API_FEATURE_ECC;
             } else {
                 throw e;
             }
         }
 
+        // If the regular SIG_CIPHER_ECDSA ALG_NULL is not available we attempt the one with fixed hash length
+        if ((api_features & API_FEATURE_ECC) == 0) {
+            // We test SHA-256 because it's available in the JCardEngine simulator but more might be available
+            if (testEcdsaDigestAlgo(MessageDigest.ALG_SHA_256)) {
+                api_features |= API_FEATURE_ECC;
+                usePrecomputedHashEcdsa = true;
+            }
+        }
+
         // API features: probe card support for 4096 bit RSA keys
         try {
-            RSAPrivateCrtKey testKey = (RSAPrivateCrtKey)KeyBuilder.buildKey(KeyBuilder.TYPE_RSA_CRT_PRIVATE, KeyBuilder.LENGTH_RSA_4096, false);
+            RSAPrivateCrtKey testKey = (RSAPrivateCrtKey)KeyBuilder.buildKey(KeyBuilder.TYPE_RSA_CRT_PRIVATE, JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT,
+                KeyBuilder.LENGTH_RSA_4096, false);
             api_features |= API_FEATURE_RSA_4096;
+            testKey = null;
         } catch (CryptoException e) {
-            if(e.getReason() == CryptoException.NO_SUCH_ALGORITHM) {
-                api_features &= ~API_FEATURE_RSA_4096;
-            } else {
+            if(e.getReason() != CryptoException.NO_SUCH_ALGORITHM) {
+                throw e;
+            }
+        } catch (TransactionException e) { // some NXP JCOP cards do throw this exception instead of CryptoException
+            if(e.getReason() != TransactionException.INTERNAL_FAILURE) {
                 throw e;
             }
         }
@@ -243,9 +259,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
             }
         }
 
-        if(JCSystem.isObjectDeletionSupported()) {
-            JCSystem.requestObjectDeletion();
-        }
+        requestObjectDeletion();
 
         state = STATE_CREATION;
         register();
@@ -744,9 +758,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
                 keys[privKeyRef].clearKey();
             }
             keys[privKeyRef] = kp.getPrivate();
-            if(JCSystem.isObjectDeletionSupported()) {
-                JCSystem.requestObjectDeletion();
-            }
+            requestObjectDeletion();
 
             // Return pubkey. See ISO7816-8 table 3.
             try {
@@ -817,9 +829,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
                 keys[privKeyRef].clearKey();
             }
             keys[privKeyRef] = privKey;
-            if(JCSystem.isObjectDeletionSupported()) {
-                JCSystem.requestObjectDeletion();
-            }
+            requestObjectDeletion();
 
             // Return pubkey. See ISO7816-8 table 3.
             try {
@@ -833,6 +843,52 @@ public class IsoApplet extends Applet implements ExtendedLength {
 
         default:
             ISOException.throwIt(ISO7816.SW_CONDITIONS_NOT_SATISFIED);
+        }
+    }
+
+    /**
+     * \brief Request object deletion
+     */
+    private static void requestObjectDeletion() {
+        if(JCSystem.isObjectDeletionSupported()) {
+            JCSystem.requestObjectDeletion();
+        }
+    }
+
+    private static boolean testEcdsaDigestAlgo(byte algo) {
+        Signature sig = null;
+        try {
+            sig = Signature.getInstance(algo, Signature.SIG_CIPHER_ECDSA, Cipher.PAD_NULL, false);
+            return true;
+        } catch (CryptoException e) {
+            if (e.getReason() == CryptoException.NO_SUCH_ALGORITHM) {
+                return false;
+            } else {
+                throw e;
+            }
+        } finally {
+            sig = null;
+            requestObjectDeletion();
+        }
+    }
+
+    private static byte getMessageDigestAlgoByLength(short length) throws ISOException {
+        switch (length) {
+        case MessageDigest.LENGTH_MD5:
+            return MessageDigest.ALG_MD5;
+        case MessageDigest.LENGTH_SHA:
+            return MessageDigest.ALG_SHA; // or ALG_RIPEMD160
+        case MessageDigest.LENGTH_SHA_224:
+            return MessageDigest.ALG_SHA_224; // or ALG_SHA3_224
+        case MessageDigest.LENGTH_SHA_256:
+            return MessageDigest.ALG_SHA_256; // or ALG_SHA3_256
+        case MessageDigest.LENGTH_SHA_384:
+            return MessageDigest.ALG_SHA_384; // or ALG_SHA3_384
+        case MessageDigest.LENGTH_SHA_512:
+            return MessageDigest.ALG_SHA_512; // or ALG_SHA3_512
+        default:
+            ISOException.throwIt(ISO7816.SW_WRONG_LENGTH);
+            return -1; // compiler is not happy otherwise
         }
     }
 
@@ -1101,7 +1157,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
             if(privKeyRef < 0) {
                 ISOException.throwIt(ISO7816.SW_DATA_INVALID);
             }
-            if(algRef == ALG_GEN_EC && ecdsaSignature == null) {
+            if(algRef == ALG_GEN_EC && (api_features & API_FEATURE_ECC) == 0) {
                 // There are cards that do not support ECDSA at all.
                 ISOException.throwIt(ISO7816.SW_FUNC_NOT_SUPPORTED);
             }
@@ -1129,7 +1185,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
                 if(keys[privKeyRef].getType() != KeyBuilder.TYPE_EC_FP_PRIVATE) {
                     ISOException.throwIt(ISO7816.SW_DATA_INVALID);
                 }
-                if(ecdsaSignature == null) {
+                if((api_features & API_FEATURE_ECC) == 0) {
                     ISOException.throwIt(ISO7816.SW_FUNC_NOT_SUPPORTED);
                 }
 
@@ -1331,9 +1387,34 @@ public class IsoApplet extends Applet implements ExtendedLength {
             // Get the key - it must be a EC private key,
             // checks have been done in MANAGE SECURITY ENVIRONMENT.
             ECPrivateKey ecKey = (ECPrivateKey) keys[currentPrivateKeyRef[0]];
-            ecdsaSignature.init(ecKey, Signature.MODE_SIGN);
-            sigLen = ecdsaSignature.sign(ram_buf, (short)0, lc, apdu.getBuffer(), (short)0);
-            apdu.setOutgoingAndSend((short) 0, sigLen);
+
+            Signature sig = null;
+            try {
+                if (usePrecomputedHashEcdsa) {
+                    try {
+                        sig = Signature.getInstance(getMessageDigestAlgoByLength(lc), Signature.SIG_CIPHER_ECDSA, Cipher.PAD_NULL, false);
+                    } catch (CryptoException e) {
+                        if (e.getReason() == CryptoException.NO_SUCH_ALGORITHM) {
+                            ISOException.throwIt(ISO7816.SW_FUNC_NOT_SUPPORTED);
+                        } else {
+                            throw e;
+                        }
+                    }
+                } else {
+                    sig = ecdsaSignature;
+                }
+
+                sig.init(ecKey, Signature.MODE_SIGN);
+                if (usePrecomputedHashEcdsa) {
+                    sigLen = sig.signPreComputedHash(ram_buf, (short)0, lc, apdu.getBuffer(), (short)0);
+                } else {
+                    sigLen = sig.sign(ram_buf, (short)0, lc, apdu.getBuffer(), (short)0);
+                }
+                apdu.setOutgoingAndSend((short) 0, sigLen);
+            } finally {
+                sig = null;
+                requestObjectDeletion();
+            }
             break;
 
         default:
@@ -1557,9 +1638,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
                 keys[currentPrivateKeyRef[0]].clearKey();
             }
             keys[currentPrivateKeyRef[0]] = rsaPrKey;
-            if(JCSystem.isObjectDeletionSupported()) {
-                JCSystem.requestObjectDeletion();
-            }
+            requestObjectDeletion();
             JCSystem.commitTransaction();
         } else {
             ISOException.throwIt(ISO7816.SW_DATA_INVALID);
@@ -1670,9 +1749,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
                 keys[currentPrivateKeyRef[0]].clearKey();
             }
             keys[currentPrivateKeyRef[0]] = ecPrKey;
-            if(JCSystem.isObjectDeletionSupported()) {
-                JCSystem.requestObjectDeletion();
-            }
+            requestObjectDeletion();
             JCSystem.commitTransaction();
         } else {
             ISOException.throwIt(ISO7816.SW_DATA_INVALID);

--- a/src/xyz/wendland/javacard/pki/isoapplet/IsoApplet.java
+++ b/src/xyz/wendland/javacard/pki/isoapplet/IsoApplet.java
@@ -140,7 +140,13 @@ public class IsoApplet extends Applet implements ExtendedLength {
     private byte[] ram_buf = null;
     private Cipher rsaPkcs1Cipher = null;
     private boolean usePrecomputedHashEcdsa = false;
-    private Signature ecdsaSignature = null;
+    private Signature ecdsaPreHashedSignature = null;
+    private Signature ecdsa16BSignature = null;
+    private Signature ecdsa20BSignature = null;
+    private Signature ecdsa28BSignature = null;
+    private Signature ecdsa32BSignature = null;
+    private Signature ecdsa48BSignature = null;
+    private Signature ecdsa64BSignature = null;
     private Signature rsaSha1PssSignature = null;
     private Signature rsaSha224PssSignature = null;
     private Signature rsaSha256PssSignature = null;
@@ -184,7 +190,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
 
         // API features: probe card support for ECDSA
         try {
-            ecdsaSignature = Signature.getInstance(MessageDigest.ALG_NULL, Signature.SIG_CIPHER_ECDSA, Cipher.PAD_NULL, false);
+            ecdsaPreHashedSignature = Signature.getInstance(MessageDigest.ALG_NULL, Signature.SIG_CIPHER_ECDSA, Cipher.PAD_NULL, false);
             usePrecomputedHashEcdsa = false;
             api_features |= API_FEATURE_ECC;
         } catch (CryptoException e) {
@@ -193,16 +199,23 @@ public class IsoApplet extends Applet implements ExtendedLength {
                  * We should not throw an exception in this cases
                  * as this would prevent installation, and we
                  * trying a different mechanism just after. */
-                ecdsaSignature = null;
+                ecdsaPreHashedSignature = null;
             } else {
                 throw e;
             }
         }
 
-        // If the regular SIG_CIPHER_ECDSA ALG_NULL is not available we attempt the one with fixed hash length
+        // If the regular SIG_CIPHER_ECDSA ALG_NULL is not available we attempt the ones with fixed hash length
         if ((api_features & API_FEATURE_ECC) == 0) {
-            // We test SHA-256 because it's available in the JCardEngine simulator but more might be available
-            if (testEcdsaDigestAlgo(MessageDigest.ALG_SHA_256)) {
+            ecdsa16BSignature = getEcdsaForDigestAlgo(MessageDigest.ALG_MD5);
+            ecdsa20BSignature = getEcdsaForDigestAlgo(MessageDigest.ALG_SHA);
+            ecdsa28BSignature = getEcdsaForDigestAlgo(MessageDigest.ALG_SHA_224);
+            ecdsa32BSignature = getEcdsaForDigestAlgo(MessageDigest.ALG_SHA_256);
+            ecdsa48BSignature = getEcdsaForDigestAlgo(MessageDigest.ALG_SHA_384);
+            ecdsa64BSignature = getEcdsaForDigestAlgo(MessageDigest.ALG_SHA_512);
+
+            if (ecdsa16BSignature != null || ecdsa20BSignature != null || ecdsa28BSignature != null ||
+                ecdsa32BSignature != null || ecdsa48BSignature != null || ecdsa64BSignature != null) {
                 api_features |= API_FEATURE_ECC;
                 usePrecomputedHashEcdsa = true;
             }
@@ -271,7 +284,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
             }
         }
 
-        requestObjectDeletion();
+        JCSystem.requestObjectDeletion();
 
         state = STATE_CREATION;
         register();
@@ -770,7 +783,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
                 keys[privKeyRef].clearKey();
             }
             keys[privKeyRef] = kp.getPrivate();
-            requestObjectDeletion();
+            JCSystem.requestObjectDeletion();
 
             // Return pubkey. See ISO7816-8 table 3.
             try {
@@ -841,7 +854,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
                 keys[privKeyRef].clearKey();
             }
             keys[privKeyRef] = privKey;
-            requestObjectDeletion();
+            JCSystem.requestObjectDeletion();
 
             // Return pubkey. See ISO7816-8 table 3.
             try {
@@ -858,30 +871,46 @@ public class IsoApplet extends Applet implements ExtendedLength {
         }
     }
 
-    /**
-     * \brief Request object deletion
-     */
-    private static void requestObjectDeletion() {
-        if(JCSystem.isObjectDeletionSupported()) {
-            JCSystem.requestObjectDeletion();
-        }
-    }
-
-    private static boolean testEcdsaDigestAlgo(byte algo) {
-        Signature sig = null;
+    private static Signature getEcdsaForDigestAlgo(byte algo) {
         try {
-            sig = Signature.getInstance(algo, Signature.SIG_CIPHER_ECDSA, Cipher.PAD_NULL, false);
-            return true;
+            return Signature.getInstance(algo, Signature.SIG_CIPHER_ECDSA, Cipher.PAD_NULL, false);
         } catch (CryptoException e) {
             if (e.getReason() == CryptoException.NO_SUCH_ALGORITHM) {
-                return false;
+                return null;
             } else {
                 throw e;
             }
-        } finally {
-            sig = null;
-            requestObjectDeletion();
         }
+    }
+
+    private Signature getSignatureByLength(short length) throws ISOException, CryptoException {
+       Signature sig = null;
+       switch (length) {
+       case MessageDigest.LENGTH_MD5:
+           sig = ecdsa16BSignature;
+           break;
+       case MessageDigest.LENGTH_SHA:
+           sig = ecdsa20BSignature;
+           break;
+       case MessageDigest.LENGTH_SHA_224:
+           sig = ecdsa28BSignature;
+           break;
+       case MessageDigest.LENGTH_SHA_256:
+           sig = ecdsa32BSignature;
+           break;
+       case MessageDigest.LENGTH_SHA_384:
+           sig = ecdsa48BSignature;
+           break;
+       case MessageDigest.LENGTH_SHA_512:
+           sig = ecdsa64BSignature;
+           break;
+       default:
+           ISOException.throwIt(ISO7816.SW_WRONG_LENGTH);
+       }
+       if (sig == null) {
+           CryptoException.throwIt(CryptoException.NO_SUCH_ALGORITHM);
+       }
+       return sig;
     }
 
     private static byte getMessageDigestAlgoByLength(short length) throws ISOException {
@@ -1401,32 +1430,19 @@ public class IsoApplet extends Applet implements ExtendedLength {
             ECPrivateKey ecKey = (ECPrivateKey) keys[currentPrivateKeyRef[0]];
 
             Signature sig = null;
-            try {
-                if (usePrecomputedHashEcdsa) {
-                    try {
-                        sig = Signature.getInstance(getMessageDigestAlgoByLength(lc), Signature.SIG_CIPHER_ECDSA, Cipher.PAD_NULL, false);
-                    } catch (CryptoException e) {
-                        if (e.getReason() == CryptoException.NO_SUCH_ALGORITHM) {
-                            ISOException.throwIt(ISO7816.SW_FUNC_NOT_SUPPORTED);
-                        } else {
-                            throw e;
-                        }
-                    }
-                } else {
-                    sig = ecdsaSignature;
-                }
-
-                sig.init(ecKey, Signature.MODE_SIGN);
-                if (usePrecomputedHashEcdsa) {
-                    sigLen = sig.signPreComputedHash(ram_buf, (short)0, lc, apdu.getBuffer(), (short)0);
-                } else {
-                    sigLen = sig.sign(ram_buf, (short)0, lc, apdu.getBuffer(), (short)0);
-                }
-                apdu.setOutgoingAndSend((short) 0, sigLen);
-            } finally {
-                sig = null;
-                requestObjectDeletion();
+            if (usePrecomputedHashEcdsa) {
+                sig = getSignatureByLength(lc);
+            } else {
+                sig = ecdsaPreHashedSignature;
             }
+
+            sig.init(ecKey, Signature.MODE_SIGN);
+            if (usePrecomputedHashEcdsa) {
+                sigLen = sig.signPreComputedHash(ram_buf, (short)0, lc, apdu.getBuffer(), (short)0);
+            } else {
+                sigLen = sig.sign(ram_buf, (short)0, lc, apdu.getBuffer(), (short)0);
+            }
+            apdu.setOutgoingAndSend((short) 0, sigLen);
             break;
 
         default:
@@ -1650,7 +1666,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
                 keys[currentPrivateKeyRef[0]].clearKey();
             }
             keys[currentPrivateKeyRef[0]] = rsaPrKey;
-            requestObjectDeletion();
+            JCSystem.requestObjectDeletion();
             JCSystem.commitTransaction();
         } else {
             ISOException.throwIt(ISO7816.SW_DATA_INVALID);
@@ -1761,7 +1777,7 @@ public class IsoApplet extends Applet implements ExtendedLength {
                 keys[currentPrivateKeyRef[0]].clearKey();
             }
             keys[currentPrivateKeyRef[0]] = ecPrKey;
-            requestObjectDeletion();
+            JCSystem.requestObjectDeletion();
             JCSystem.commitTransaction();
         } else {
             ISOException.throwIt(ISO7816.SW_DATA_INVALID);

--- a/src/xyz/wendland/javacard/pki/isoapplet/IsoApplet.java
+++ b/src/xyz/wendland/javacard/pki/isoapplet/IsoApplet.java
@@ -22,7 +22,6 @@ package xyz.wendland.javacard.pki.isoapplet;
 import javacard.framework.Applet;
 import javacard.framework.ISO7816;
 import javacard.framework.ISOException;
-import javacard.framework.TransactionException;
 import javacard.framework.APDU;
 import javacard.framework.JCSystem;
 import javacard.framework.Util;
@@ -229,10 +228,6 @@ public class IsoApplet extends Applet implements ExtendedLength {
             testKey = null;
         } catch (CryptoException e) {
             if(e.getReason() != CryptoException.NO_SUCH_ALGORITHM) {
-                throw e;
-            }
-        } catch (TransactionException e) { // some NXP JCOP cards do throw this exception instead of CryptoException
-            if(e.getReason() != TransactionException.INTERNAL_FAILURE) {
                 throw e;
             }
         }


### PR DESCRIPTION
This adds ECDSA signature to cards that do not support `SIG_CIPHER_ECDSA` with `ALG_NULL` signatures, but still support the `Signature.signPreComputedHash` method as in practice ECDSA will almost always be used with a hash.

The correct hash to use is detected according to the length, so in practice this will accept signing messages of length 16 (if MD5 is available), 20, 28, 32, 48, 64

I kept the previous `ALG_NULL` implementation if it is available in order to not break existing functionality

I'm not particularly happy with `Signature` instances being created in a transient manner as on cards without object deletion this could lead to memory leaking, maybe we should keep alive one instance per hash length? Or move to JC 3.0.5 where `Signature.OneShot` is available, like I did in [my main-3.0.5 branch](https://github.com/suut/IsoApplet/tree/main-3.0.5).

This is the script I'm using to test, tested to work with JCardEngine as well as a J2R180 card:
```bash
#!/bin/bash -x

PIN=1234
CURVE=brainpoolP256r1

# initialize, wait for OpenSC to find the right application which is slower on a simulator
{ sleep 2.5; echo "$PIN"; sleep 0.5; echo "$PIN"; sleep 0.5; echo; } | pkcs15-init -C 

# generate key pair
pkcs15-init -a ff -G EC:"$CURVE" -u sign --pin "$PIN"

# get public key
pkcs15-tool --read-public-key 45 > public-key.pem

# generate fake hash, SHA-256 / 32 bytes
dd if=/dev/urandom of=hash.bin iflag=count_bytes count=32

# sign
pkcs15-crypt -i hash.bin -f openssl --sha-256 --key 45 --sign --raw --pin "$PIN" > signature.bin

# verify signature
openssl pkeyutl -in hash.bin -sigfile signature.bin -inkey public-key.pem -pubin -verify

# cleanup
rm -f public-key.pem hash.bin signature.bin
```